### PR TITLE
Add `net-http-persistent` to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
+  gem 'net-http-persistent', '~> 3'
   gem 'pry'
   gem 'pry-byebug'
   gem 'rake', '~> 12.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,22 @@
 PATH
   remote: .
   specs:
-    files.com (1.0.0)
-      faraday
+    files.com (1.0.19)
+      faraday (>= 0.12.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     byebug (11.0.1)
     coderay (1.1.2)
+    connection_pool (2.2.2)
     diff-lcs (1.3)
     faraday (1.0.0)
       multipart-post (>= 1.2, < 3)
     method_source (0.9.2)
     multipart-post (2.1.1)
+    net-http-persistent (3.1.0)
+      connection_pool (~> 2.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -40,6 +43,7 @@ PLATFORMS
 
 DEPENDENCIES
   files.com!
+  net-http-persistent (~> 3)
   pry
   pry-byebug
   rake (~> 12.0.0)


### PR DESCRIPTION
# Context
Forked the SDK repo, ran `bundle`, attempted to run tests and received the following error message:

```
missing dependency for Faraday::Adapter::NetHttpPersistent: cannot load such file -- net/http/persistent (RuntimeError)
```

# Changes
Added `net-http-persistent` gem to dependencies in `Gemfile` (per this issue: https://github.com/lostisland/faraday/issues/463)

## Full Trace
```
± |master U:1 ✗| → ruby test.rb
I, [2020-02-28T12:42:33.789985 #2892]  INFO -- : message=Request method=post num_retries=0 path=/sessions
D, [2020-02-28T12:42:33.790057 #2892] DEBUG -- : message=Request details body={:username=>"sessionuser", :password=>"sessionuserpassword"}
E, [2020-02-28T12:42:33.790250 #2892] ERROR -- : message=Error elapsed=0.000269667 error_message=missing dependency for Faraday::Adapter::NetHttpPersistent: cannot load such file -- net/http/persistent method=post path=/sessions
Traceback (most recent call last):
	12: from test.rb:75:in `<main>'
	11: from test.rb:65:in `test_sessions'
	10: from ~/dev/forks/files-sdk-ruby/lib/files.com/models/session.rb:222:in `create'
	 9: from ~/dev/forks/files-sdk-ruby/lib/files.com/api.rb:19:in `send_request'
	 8: from ~/dev/forks/files-sdk-ruby/lib/files.com/api_client.rb:103:in `execute_request'
	 7: from ~/dev/forks/files-sdk-ruby/lib/files.com/api_client.rb:162:in `execute_request_with_rescues'
	 6: from ~/dev/forks/files-sdk-ruby/lib/files.com/api_client.rb:104:in `block in execute_request'
	 5: from ~/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/faraday-1.0.0/lib/faraday/connection.rb:492:in `run_request'
	 4: from ~/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/faraday-1.0.0/lib/faraday/rack_builder.rb:153:in `build_response'
	 3: from ~/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/faraday-1.0.0/lib/faraday/rack_builder.rb:166:in `app'
	 2: from ~/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/faraday-1.0.0/lib/faraday/rack_builder.rb:173:in `to_app'
	 1: from ~/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/faraday-1.0.0/lib/faraday/rack_builder.rb:56:in `build'
~/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/faraday-1.0.0/lib/faraday/dependency_loader.rb:18:in `new': missing dependency for Faraday::Adapter::NetHttpPersistent: cannot load such file -- net/http/persistent (RuntimeError)
```