### PR TITLE
Change list to list_for

### DIFF
--- a/lib/files.com/models/folder.rb
+++ b/lib/files.com/models/folder.rb
@@ -41,7 +41,7 @@ module Files
     end
 
     def self.entries(path)
-      list(path)
+      list_for(path)
     end
 
     def self.exist?(*args)
@@ -55,7 +55,7 @@ module Files
     def self.find_recursive(path, type = "dir")
       return path if type == "file"
 
-      list(path).map { |c| find_recursive(c.path, c.type) }.flatten.compact
+      list_for(path).map { |c| find_recursive(c.path, c.type) }.flatten.compact
     end
 
     def self.get(path, params = {}, options = {})
@@ -63,7 +63,7 @@ module Files
     end
 
     def self.foreach(path, _encoding)
-      list(path, {}).each { |x| yield x }
+      list_for(path, {}).each { |x| yield x }
     end
 
     def self.getwd(*_args)
@@ -109,7 +109,7 @@ module Files
     def initialize(*args)
       @attributes = (args[0].is_a?(Hash) && args[0]) || {}
       @options = (args[1].is_a?(Hash) && args[1]) || {}
-      @attributes['path'] = args[0] if args[0].is_a?(String)
+      @attributes[:path] = args[0] if args[0].is_a?(String)
     end
 
     def close(*args); end
@@ -123,7 +123,8 @@ module Files
     end
 
     def contents
-      @contents ||= Folder.list(path, {}, @options)
+      puts "contents: path is #{path}"
+      @contents ||= Folder.list_for(path, {}, @options)
     end
 
     def stats

--- a/test/test.rb
+++ b/test/test.rb
@@ -32,7 +32,9 @@ end
 
 def test_folder_operations
   name = "folder_#{Time.now.to_i}"
-  Files::Folder.create(name)
+  folder_file = Files::Folder.create(name)
+  all_files = Files::Folder['/']
+  top_level_files = Files::Folder.entries('/')
   file = Files::File.find(name)
   file.copy("#{name}_copy")
   file.delete
@@ -40,6 +42,11 @@ def test_folder_operations
   file.move("#{name}_moved_copy")
   file = Files::File.find("#{name}_moved_copy")
   Files::Folder.create("#{file.path}/child")
+  Files::Folder.foreach('/', 'utf-8') { |file_ent| puts file.display_name }
+  folder = Files::Folder.new('/')
+  contents = folder.contents
+
+  # cleanup
   Files::FileUtils.rm_r(file.path)
 end
 


### PR DESCRIPTION
Multiple methods in `Files::Folder` refer to a `list` method that does
not appear in the method, or in its change history. There is a
`list_for` method that appears to have the correct method signature to
take its place.

Fixes #3 