### PR TITLE
Ruby 3 fixes

### DIFF
--- a/lib/files.com/api_client.rb
+++ b/lib/files.com/api_client.rb
@@ -287,13 +287,13 @@ module Files
         code: error_data[:code] || resp.http_status,
       }
 
-      return APIError.new(error_data[:message], opts) unless resp&.data&.dig(:type)
+      return APIError.new(error_data[:message], **opts) unless resp&.data&.dig(:type)
 
       begin
         error_class = Files.const_get(resp.data[:type].split("/").map { |piece| piece.split("-").map(&:capitalize).join('') + 'Error' }.join("::"))
         error_class.new(error_data[:message], opts)
       rescue NameError
-        APIError.new(error_data[:message], opts)
+        APIError.new(error_data[:message], **opts)
       end
     end
 


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Because https://github.com/Files-com/files-sdk-ruby/blob/879859d2376193222d6a61579f619b2c7770ebdc/lib/files.com/errors.rb#L45

is declared with `**`, it's expected that calls will use keyword args (e.g. `APIError.new('hello', x: 1, y: 2)`. If using a hash in place of keyword args, it needs to be prefaced by `**`